### PR TITLE
chore: Add organization-wide `renovate.json`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,19 @@
+{
+  "schedule": ["every weekend"],
+  "labels": ["dependencies"],
+  "separateMajorMinor": "false",
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
+      "groupName": "devDependencies",
+      "semanticCommitType": "chore"
+    },
+    {
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest", "lockFileMaintenance", "rollback", "bump"],
+      "groupName": "dependencies",
+      "semanticCommitType": "fix"
+    }
+  ]
+}


### PR DESCRIPTION
### Description

There are many commits named "sync with the repository template"
https://github.com/search?p=2&q=org%3Aatom-community+chore%3A+sync+with+the+repository+template&type=Commits

But instead of adding a template for every repository, there can be a single file at the .github repo:
https://docs.renovatebot.com/getting-started/installing-onboarding/#configuration-location

### Drawbacks

Hmm, maybe there shouldn't be any pull requests for deprecated repositories. [Should those be archived?]

And dealing with all those commits and removing all those files feels very tedious.

### Alternative

Temporarily don't autoMerge devDependencies?

I'll wait to see what the renovate bot says it will do